### PR TITLE
Fix data cleaning for Inpatient and Outpatient values

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -153,8 +153,8 @@ const ProviderLocationMapWithLegend = () => {
         latitude,
         county,
         services: {
-          inpatient: item['Inpatient']?.toLowerCase() === 'true' || item['Inpatient'] === true,
-          outpatient: item['Outpatient']?.toLowerCase() === 'true' || item['Outpatient'] === true,
+          inpatient: item['Inpatient']?.toString().trim().replace(/['"]/g, '').toLowerCase() === 'true' || item['Inpatient'] === true,
+          outpatient: item['Outpatient']?.toString().trim().replace(/['"]/g, '').toLowerCase() === 'true' || item['Outpatient'] === true,
           children: item['Children']?.toLowerCase() === 'true' || item['Children'] === true,
           adults: item['Adults']?.toLowerCase() === 'true' || item['Adults'] === true
         }


### PR DESCRIPTION
This PR fixes the data cleaning for Inpatient and Outpatient values by:

1. Converting values to strings
2. Trimming leading/trailing whitespace
3. Removing any quotes
4. Converting to lowercase for consistent comparison

This ensures that values like "Inpatient " and "Outpatient " are properly handled.